### PR TITLE
Removed unnecesssary boost-build.jam file,

### DIFF
--- a/boost-build.jam
+++ b/boost-build.jam
@@ -1,1 +1,0 @@
-boost-build ../boost/tools/build/v2 ;


### PR DESCRIPTION
 should use BOOST_BUILD_PATH and BOOST_ROOT environment variables instead

This addresses #4.
